### PR TITLE
Fixed NullPointerException when initializing Podcast with feed only constructor and added unit test for it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,5 +20,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/icosillion/podengine/models/Podcast.java
+++ b/src/main/java/com/icosillion/podengine/models/Podcast.java
@@ -37,11 +37,18 @@ public class Podcast {
     private ITunesChannelInfo iTunesChannelInfo;
     private List<Episode> episodes;
 
-    public Podcast(URL feed) throws InvalidFeedException {
+    public Podcast(URL feed) throws InvalidFeedException, MalformedFeedException {
         InputStream is = null;
         try {
             is = feed.openStream();
-            this.document = DocumentHelper.parseText(IOUtils.toString(is));
+            this.feedURL = feed;
+            this.xmlData = IOUtils.toString(is);
+            this.document = DocumentHelper.parseText(xmlData);
+            this.rootElement = this.document.getRootElement();
+            this.channelElement = this.rootElement.element("channel");
+            if(this.channelElement == null) {
+                throw new MalformedFeedException("Missing required channel element.");
+            }
         } catch (IOException e) {
             throw new InvalidFeedException("Error reading feed.", e);
         } catch (DocumentException e) {

--- a/src/test/java/com/icosillion/podengine/models/PodcastTest.java
+++ b/src/test/java/com/icosillion/podengine/models/PodcastTest.java
@@ -1,0 +1,31 @@
+package com.icosillion.podengine.models;
+
+import com.icosillion.podengine.exceptions.InvalidFeedException;
+import com.icosillion.podengine.exceptions.MalformedFeedException;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Podcast unit test class.
+ */
+public class PodcastTest {
+
+    @Test
+    public void testPodcastFeedCreation(){
+        try {
+            Podcast podcast = new Podcast(new URL("http://feeds.feedburner.com/thetimferrissshow"));
+            assertEquals("The Tim Ferriss Show", podcast.getTitle());
+        } catch (InvalidFeedException e) {
+            e.printStackTrace();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (MalformedFeedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
I've a small side project that involves some podcast feed parsing and I'm using your library. Looks nice! I've fixed a small issue that had a NPE thrown when using the feed only constructor. I've added JUnit as a dependency and a unit test for this issue. I'm not sure if you'd like to introduce this dependency.

Regards,
João